### PR TITLE
Fix Slack invite form processing

### DIFF
--- a/includes/class-myog-slack-guest-invite.php
+++ b/includes/class-myog-slack-guest-invite.php
@@ -170,7 +170,10 @@ class Myog_Slack_Guest_Invite {
 		$plugin_public = new Myog_Slack_Guest_Invite_Public( $this->get_plugin_name(), $this->get_version() );
 
 		$this->loader->add_action( 'wp_enqueue_scripts', $plugin_public, 'enqueue_styles' );
-		$this->loader->add_action( 'wp_enqueue_scripts', $plugin_public, 'enqueue_scripts' );
+                $this->loader->add_action( 'wp_enqueue_scripts', $plugin_public, 'enqueue_scripts' );
+
+                // Handle invite form submissions
+                $this->loader->add_action( 'init', $plugin_public, 'check_post' );
 
 	}
 

--- a/myog-slack-guest-invite.php
+++ b/myog-slack-guest-invite.php
@@ -27,7 +27,12 @@
 
 // If this file is called directly, abort.
 if ( ! defined( 'WPINC' ) ) {
-	die;
+        die;
+}
+
+// Ensure PHP sessions are available for storing form messages
+if ( ! session_id() ) {
+        session_start();
 }
 
 


### PR DESCRIPTION
## Summary
- process invite form submissions by hooking `check_post` on `init`
- initialize PHP session for form messages

## Testing
- `php` (fails: command not found)
