### PR TITLE
Fix Requests::post call argument count

### DIFF
--- a/includes/slack-interface/class-slack.php
+++ b/includes/slack-interface/class-slack.php
@@ -220,7 +220,7 @@ class Slack {
 		$response = Requests::post( 
 			$this->get_api_url('users.admin.invite'), 
 			$this->get_resquest_headers(false), 
-			$data,
+			$data
 		);
 		
 		// Handle the JSON response


### PR DESCRIPTION
## Summary
- fix `Requests::post` call in Slack interface to pass only three arguments

## Testing
- `php -l` *(fails: command not found)*