### PR TITLE
Add PHPUnit tests for Slack classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,13 @@ wordpress_slack_invite/
 - Experiment with the plugin in a WordPress environment to see the form and API calls in action.
 - Review how the `Slack` class builds HTTP requests with the Requests library to extend functionality.
 - Explore WordPress Plugin Boilerplate conventions used by the classes to add hooks or features.
+
+## Running Tests
+
+This repository uses [PHPUnit](https://phpunit.de/) for unit testing. After installing PHPUnit, run the test suite from the project root:
+
+```bash
+phpunit
+```
+
+The configuration file `phpunit.xml` sets up the bootstrap script and test directory.

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/bootstrap.php" colors="true">
+    <testsuites>
+        <testsuite name="Plugin Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/SlackAccessTest.php
+++ b/tests/SlackAccessTest.php
@@ -1,0 +1,41 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use Slack_Interface\Slack_Access;
+
+class SlackAccessTest extends TestCase {
+    public function test_to_json() {
+        $data = [
+            'access_token' => 'token123',
+            'scope' => ['read', 'write'],
+            'team_name' => 'Team',
+            'team_id' => 'TID',
+            'incoming_webhook' => ['url' => 'https://hooks.slack.com/services/TOKEN', 'channel' => 'general'],
+        ];
+        $access = new Slack_Access($data);
+        $this->assertEquals($data, json_decode($access->to_json(), true));
+    }
+
+    public function test_is_configured() {
+        $configured = new Slack_Access(['access_token' => 'abc']);
+        $this->assertTrue($configured->is_configured());
+
+        $empty = new Slack_Access([]);
+        $this->assertFalse($empty->is_configured());
+    }
+
+    public function test_getters() {
+        $data = [
+            'access_token' => 'token456',
+            'team_name' => 'Example',
+            'team_id' => 'T456',
+            'incoming_webhook' => ['url' => 'https://hooks.slack.com/services/TOKEN2', 'channel' => 'random'],
+        ];
+        $access = new Slack_Access($data);
+
+        $this->assertSame('token456', $access->get_access_token());
+        $this->assertSame('Example', $access->get_team_name());
+        $this->assertSame('T456', $access->get_team_id());
+        $this->assertSame('https://hooks.slack.com/services/TOKEN2', $access->get_incoming_webhook());
+        $this->assertSame('random', $access->get_incoming_webhook_channel());
+    }
+}

--- a/tests/SlackTeamTest.php
+++ b/tests/SlackTeamTest.php
@@ -1,0 +1,38 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use Slack_Interface\Slack_Team;
+
+class SlackTeamTest extends TestCase {
+    public function test_to_json() {
+        $data = [
+            'id' => 'T123',
+            'name' => 'My Team',
+            'domain' => 'myteam',
+            'email_domain' => 'example.com',
+            'icons' => ['image_68' => 'icon.png'],
+            'enterprise_id' => 'E1',
+            'enterprise_name' => 'My Enterprise',
+        ];
+        $team = new Slack_Team($data);
+        $this->assertEquals($data, json_decode($team->to_json(), true));
+    }
+
+    public function test_getters_and_setters() {
+        $team = new Slack_Team([]);
+        $team->set_id('T234');
+        $team->set_name('Another');
+        $team->set_domain('another');
+        $team->set_email_domain('another.com');
+        $team->set_icons(['img' => 'icon.png']);
+        $team->set_enterprise_id('E2');
+        $team->set_enterprise_name('Another Enterprise');
+
+        $this->assertSame('T234', $team->get_id());
+        $this->assertSame('Another', $team->get_name());
+        $this->assertSame('another', $team->get_domain());
+        $this->assertSame('another.com', $team->get_email_domain());
+        $this->assertEquals(['img' => 'icon.png'], $team->get_icons());
+        $this->assertSame('E2', $team->get_enterprise_id());
+        $this->assertSame('Another Enterprise', $team->get_enterprise_name());
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,3 @@
+<?php
+require_once __DIR__ . '/../includes/slack-interface/class-slack-access.php';
+require_once __DIR__ . '/../includes/slack-interface/class-slack-team.php';


### PR DESCRIPTION
## Summary
- set up `phpunit.xml` and test bootstrap
- add unit tests for `Slack_Access` and `Slack_Team`
- document how to run the tests

## Testing
- `phpunit` *(fails: command not found)*