### PR TITLE
Add WordPress option stubs for PHPUnit

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,6 @@
+<?php
+// Bootstrap file for PHPUnit tests.
+// Load WordPress option stubs so tests can run without WordPress.
+require_once __DIR__ . '/wp-option-stubs.php';
+
+// Additional bootstrap logic (autoload, etc.) can be placed here.

--- a/tests/wp-option-stubs.php
+++ b/tests/wp-option-stubs.php
@@ -1,0 +1,21 @@
+<?php
+
+// Global array to mimic WordPress option storage during tests.
+if (!isset($GLOBALS['_wp_option_store'])) {
+    $GLOBALS['_wp_option_store'] = [];
+}
+
+if (!function_exists('get_option')) {
+    function get_option($name, $default = false) {
+        return array_key_exists($name, $GLOBALS['_wp_option_store']) ? $GLOBALS['_wp_option_store'][$name] : $default;
+    }
+}
+
+if (!function_exists('update_option')) {
+    function update_option($name, $value) {
+        $GLOBALS['_wp_option_store'][$name] = $value;
+        return true;
+    }
+}
+
+?>


### PR DESCRIPTION
## Summary
- add simple in-memory stubs for `get_option` and `update_option`
- load the stubs from `tests/bootstrap.php` for running PHPUnit without WordPress

## Testing
- `phpunit -c phpunit.xml` *(fails: `phpunit` not found)*