### PR TITLE
Add CI workflow for PHPUnit

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -1,0 +1,44 @@
+name: PHPUnit
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+          tools: phpunit
+
+      - name: Get Composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
+        if: ${{ hashFiles('**/composer.json') != '' }}
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v3
+        if: ${{ hashFiles('**/composer.json') != '' }}
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Install dependencies
+        run: composer install --no-progress --prefer-dist --no-interaction
+        if: ${{ hashFiles('**/composer.json') != '' }}
+
+      - name: Run PHPUnit
+        run: |
+          if [ -f vendor/bin/phpunit ]; then
+            vendor/bin/phpunit
+          else
+            phpunit
+          fi

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Slack Guest Invite
+![CI](https://github.com/owner/repo/actions/workflows/phpunit.yml/badge.svg)
 How to make it work
 To make this plugin work you will have to create your own application with slack!
 
@@ -90,3 +91,7 @@ wordpress_slack_invite/
 - Experiment with the plugin in a WordPress environment to see the form and API calls in action.
 - Review how the `Slack` class builds HTTP requests with the Requests library to extend functionality.
 - Explore WordPress Plugin Boilerplate conventions used by the classes to add hooks or features.
+
+### Continuous Integration
+
+Unit tests run automatically on GitHub Actions for every push and pull request.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow that sets up PHP and runs PHPUnit
- cache Composer dependencies when `composer.json` is present
- show CI badge in the README and mention automatic tests

## Testing
- `phpunit --version` *(fails: command not found)*