### PR TITLE
Add Slack class tests with stubs

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/bootstrap.php">
+    <testsuites>
+        <testsuite name="SlackInterface">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/SlackTest.php
+++ b/tests/SlackTest.php
@@ -1,0 +1,70 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use Slack_Interface\Slack;
+
+class SlackTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        Requests::reset();
+        $GLOBALS['wp_options'] = [];
+        $GLOBALS['wp_options']['myog_slack_access'] = json_encode([
+            'access_token' => 'token',
+            'scope' => [],
+            'team_name' => 'Test Team',
+            'team_id' => 'T123',
+            'incoming_webhook' => [
+                'url' => 'https://hooks.slack.com/services/testhook',
+                'channel' => 'C123'
+            ],
+        ]);
+    }
+
+    public function test_get_api_url_uses_team_domain()
+    {
+        $GLOBALS['wp_options']['myog_slack_team'] = json_encode([
+            'id' => 'T123',
+            'name' => 'Test Team',
+            'domain' => 'myteam'
+        ]);
+
+        $slack = new Slack();
+        $url = $slack->get_api_url('users.admin.invite');
+        $this->assertSame('https://myteam.slack.com/api/users.admin.invite', $url);
+    }
+
+    public function test_get_channels_parses_channel_ids()
+    {
+        Requests::addResponse(json_encode([
+            'ok' => true,
+            'channels' => [
+                (object)['id' => 'C1', 'name' => 'general', 'is_private' => false],
+                (object)['id' => 'C2', 'name' => 'random', 'is_private' => false],
+                (object)['id' => 'C3', 'name' => 'secret', 'is_private' => true],
+            ],
+        ]));
+
+        $GLOBALS['wp_options']['myog_slack_team'] = json_encode(['domain' => 'myteam']);
+        $slack = new Slack();
+        $ids = $slack->get_channels('general,random');
+
+        $this->assertSame(['C1', 'C2'], $ids);
+        $this->assertStringContainsString('conversations.list', Requests::$requests[0]['url']);
+    }
+
+    public function test_send_notification_posts_to_webhook()
+    {
+        Requests::addResponse('ok');
+
+        $GLOBALS['wp_options']['myog_slack_team'] = json_encode(['domain' => 'myteam']);
+        $slack = new Slack();
+        $slack->send_notification('Hello');
+
+        $this->assertNotEmpty(Requests::$requests);
+        $request = Requests::$requests[0];
+        $this->assertSame('https://hooks.slack.com/services/testhook', $request['url']);
+        $payload = json_decode($request['data'], true);
+        $this->assertSame('Hello', $payload['text']);
+        $this->assertSame('C123', $payload['channel']);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,8 @@
+<?php
+require __DIR__ . '/stubs/Requests.php';
+require __DIR__ . '/stubs/wp_functions.php';
+
+require dirname(__DIR__) . '/includes/slack-interface/class-slack-access.php';
+require dirname(__DIR__) . '/includes/slack-interface/class-slack-team.php';
+require dirname(__DIR__) . '/includes/slack-interface/class-slack-api-exception.php';
+require dirname(__DIR__) . '/includes/slack-interface/class-slack.php';

--- a/tests/stubs/Requests.php
+++ b/tests/stubs/Requests.php
@@ -1,0 +1,27 @@
+<?php
+class Requests {
+    public static $requests = [];
+    public static $responses = [];
+
+    public static function addResponse($body) {
+        self::$responses[] = (object)['body' => $body];
+    }
+
+    public static function post($url, $headers = [], $data = [], $options = []) {
+        self::$requests[] = [
+            'url' => $url,
+            'headers' => $headers,
+            'data' => $data,
+            'options' => $options,
+        ];
+        if (self::$responses) {
+            return array_shift(self::$responses);
+        }
+        return (object)['body' => ''];
+    }
+
+    public static function reset() {
+        self::$requests = [];
+        self::$responses = [];
+    }
+}

--- a/tests/stubs/wp_functions.php
+++ b/tests/stubs/wp_functions.php
@@ -1,0 +1,11 @@
+<?php
+$GLOBALS['wp_options'] = [];
+
+function get_option($name) {
+    return isset($GLOBALS['wp_options'][$name]) ? $GLOBALS['wp_options'][$name] : false;
+}
+
+function update_option($name, $value) {
+    $GLOBALS['wp_options'][$name] = $value;
+    return true;
+}


### PR DESCRIPTION
## Summary
- add PHPUnit configuration
- create stubs for Requests class and WordPress functions
- bootstrap tests with stubs and Slack class loading
- add new tests covering Slack interface methods

## Testing
- `phpunit --configuration phpunit.xml` *(fails: command not found)*