### PR TITLE
Add WordPress plugin deploy action

### DIFF
--- a/.github/workflows/deploy-wordpress.yml
+++ b/.github/workflows/deploy-wordpress.yml
@@ -1,0 +1,20 @@
+name: Deploy to WordPress
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Deploy to WordPress
+        uses: 10up/action-wordpress-plugin-deploy@v2
+        with:
+          slug: myog-slack-guest-invite
+          generate-zip: true
+        env:
+          SVN_USERNAME: ${{ secrets.WP_SVN_USERNAME }}
+          SVN_PASSWORD: ${{ secrets.WP_SVN_PASSWORD }}

--- a/README.md
+++ b/README.md
@@ -108,3 +108,7 @@ phpunit
 
 The configuration file `phpunit.xml` sets up the bootstrap script and test directory.
 
+
+### Deployment to WordPress.org
+
+Merging changes to the `master` branch triggers the `deploy-wordpress.yml` GitHub Actions workflow. This workflow uses `10up/action-wordpress-plugin-deploy` to push the plugin to the WordPress.org SVN repository and generates a zip archive. Configure repository secrets `WP_SVN_USERNAME` and `WP_SVN_PASSWORD` with your SVN credentials so the action can authenticate.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to deploy the plugin to WordPress.org
- document automated deployment in the README

## Testing
- `phpunit` *(fails: command not found)*